### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ check other ways to use `DesktopNotification` in [example](https://github.com/ed
 * find an app for your OS in build/node-webkit-desktop-notification
 * [play](http://screencast.com/t/bUxB6vNvW8BN)
 
-##API
+## API
 
 ### Class: DesktopNotification(title, options)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
